### PR TITLE
update to 21.10 stable/21.12 nightly

### DIFF
--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 pkg = "rapids"
 if(sys.argv[1] == "nightly"):
-  release =  ["rapidsai-nightly", "21.10"]
+  release =  ["rapidsai-nightly", "21.12"]
   print("Installing RAPIDS Nightly "+release[1])
 else:
-  release = ["rapidsai", "21.08"]
+  release = ["rapidsai", "21.10"]
   print("Installing RAPIDS Stable "+release[1])
 
 pkg = "rapids"


### PR DESCRIPTION
- [ ] run 21.10 tests during code freeze
- [ ] run 21.12 tests once conda packages released
- [ ] certify working capacity
- [ ] Optional: test 21.10 BlazingSQL