### PR TITLE
update to 21.10 stable/21.12 nightly

### DIFF
--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -14,7 +14,7 @@ else:
 pkg = "rapids"
 print("Starting the RAPIDS install on Colab.  This will take about 15 minutes.")
 
-output = subprocess.Popen(["conda install -y --prefix /usr/local -c "+release[0]+" -c nvidia -c conda-forge python=3.7 cudatoolkit=11.0 "+pkg+"="+release[1]+" llvmlite gcsfs openssl"], shell=True, stderr=subprocess.STDOUT, 
+output = subprocess.Popen(["conda install -y --prefix /usr/local -c "+release[0]+" -c nvidia -c conda-forge python=3.7 cudatoolkit=11.2 "+pkg+"="+release[1]+" llvmlite gcsfs openssl"], shell=True, stderr=subprocess.STDOUT, 
     stdout=subprocess.PIPE)
 for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
   if(line == ""):

--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 pkg = "rapids"
 if(sys.argv[1] == "nightly"):
-  release =  ["rapidsai-nightly", "21.10"]
+  release =  ["rapidsai-nightly", "21.12"]
   print("Installing RAPIDS Nightly "+release[1])
 else:
-  release = ["rapidsai", "21.08"]
+  release = ["rapidsai", "21.10"]
   print("Installing RAPIDS Stable "+release[1])
 
 pkg = "rapids"


### PR DESCRIPTION
- [x] run 21.10 tests during code freeze
- [x] run 21.12 tests once conda packages released
- [x] certify working capacity
- [x] Optional: test 21.10 BlazingSQL