### PR TITLE
update: cffi install version (nvtabular < 1.4.0)

### DIFF
--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -18,7 +18,7 @@ for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
     break
   else:
     print(line.rstrip())
-output = subprocess.Popen(["pip install cffi==1.15.0"], shell=True, stderr=subprocess.STDOUT, 
+output = subprocess.Popen(["pip install cffi==1.15.1"], shell=True, stderr=subprocess.STDOUT, 
     stdout=subprocess.PIPE)
 for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
   if(line == ""):


### PR DESCRIPTION
desc: colab nvtabular, cffi error fix

< using nvtabular==1.3.0, higher version returns [ModuleNotFoundError: No module named 'merlin.dag.executors'] >

Version mismatch: this is the 'cffi' package version 1.15.1, located in '/usr/local/lib/python3.7/dist-packages/cffi/api.py'. When we import the top-level '_cffi_backend' extension module, we get version 1.15.0, located in '/usr/local/lib/python3.7/site-packages/_cffi_backend.cpython-37m-x86_64-linux-gnu.so'. The two versions should be equal; check your installation.



detail
Install process


# cell-1
!git clone https://github.com/rapidsai/rapidsai-csp-utils.git
!python rapidsai-csp-utils/colab/env-check.py

!bash rapidsai-csp-utils/colab/update_gcc.sh -qq
import os
os._exit(00)

# cell-2
!pip install -q condacolab
import condacolab
condacolab.install()

# cell-3
!python rapidsai-csp-utils/colab/install_rapids.py stable

import os
os.environ['NUMBAPRO_NVVM'] = '/usr/local/cuda/nvvm/lib64/libnvvm.so'
os.environ['NUMBAPRO_LIBDEVICE'] = '/usr/local/cuda/nvvm/libdevice/'
os.environ['CONDA_PREFIX'] = '/usr/local'

# cell-4
!pip install -qqq transformers4rec[pytorch,nvtabular]
!conda install -c nvidia -c rapidsai -c numba -c conda-forge nvtabular -y

After fixing cffi version, the nvtabular workflow works