### PR TITLE
[WIP] Update conda install for python3.10/cuda 11.8 env

### DIFF
--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -29,16 +29,16 @@ for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
 # Install RAPIDS
 pkg = "rapids"
 if(sys.argv[1] == "nightly"):
-  release =  ["rapidsai-nightly", "23.02"]
+  release =  ["rapidsai-nightly", "23.06"]
   print("Installing RAPIDS Nightly "+release[1])
 else:
-  release = ["rapidsai", "22.12"]
+  release = ["rapidsai", "23.04"]
   print("Installing RAPIDS Stable "+release[1])
 
 pkg = "rapids"
 print("Starting the RAPIDS install on Colab.  This will take about 15 minutes.")
 
-output = subprocess.Popen(["conda install -y --prefix /usr/local -c "+release[0]+" -c nvidia -c conda-forge python=3.9 cudatoolkit=11.2 "+pkg+"="+release[1]+" llvmlite gcsfs openssl dask-sql"], shell=True, stderr=subprocess.STDOUT, 
+output = subprocess.Popen(["conda install -y --prefix /usr/local -c "+release[0]+" -c nvidia -c conda-forge python=3.10 cudatoolkit=11.8 "+pkg+"="+release[1]+" llvmlite gcsfs openssl dask-sql"], shell=True, stderr=subprocess.STDOUT, 
     stdout=subprocess.PIPE)
 for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
   if(line == ""):
@@ -49,7 +49,7 @@ for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
 
 print("RAPIDS conda installation complete.  Updating Colab's libraries...")
 import sys, os, shutil
-sys.path.append('/usr/local/lib/python3.9/site-packages/')
+sys.path.append('/usr/local/lib/python3.10/site-packages/')
 os.environ['NUMBAPRO_NVVM'] = '/usr/local/cuda/nvvm/lib64/libnvvm.so'
 os.environ['NUMBAPRO_LIBDEVICE'] = '/usr/local/cuda/nvvm/libdevice/'
 


### PR DESCRIPTION
Colab has updated to python 3.10 and cuda 11.8, enabling us to install latest RAPDIS and nightly versions.  This code updates the installer accordingly

Closes #78 