### PR TITLE
Pin RAPIDS version for Pascal gpu

### DIFF
--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -3,6 +3,29 @@ import os, sys, io
 import subprocess
 from pathlib import Path
 
+try: 
+  import pynvml
+except:
+  output = subprocess.Popen(["pip install pynvml"], shell=True, stderr=subprocess.STDOUT, 
+      stdout=subprocess.PIPE)
+  for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
+    if(line == ""):
+      break
+    else:
+      print(line.rstrip())
+  import pynvml
+try:
+  pynvml.nvmlInit()
+except:
+  raise Exception("""
+                  Unfortunately you're in a Colab instance that doesn't have a GPU.
+
+                  Please make sure you've configured Colab to request a GPU Instance Type.
+               
+                  Go to 'Runtime -> Change Runtime Type --> under the Hardware Accelerator, select GPU', then try again."""
+  )
+gpu_name = pynvml.nvmlDeviceGetName(pynvml.nvmlDeviceGetHandleByIndex(0))
+
 # CFFI fix with pip 
 output = subprocess.Popen(["pip uninstall --yes cffi"], shell=True, stderr=subprocess.STDOUT, 
     stdout=subprocess.PIPE)
@@ -33,14 +56,18 @@ for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
   else:
     print(line.rstrip())
 
-# Install RAPIDS
+# Install RAPIDS, overriding install version if a Pascal GPU is found
 pkg = "rapids"
-if(sys.argv[1] == "nightly"):
-  release =  ["rapidsai-nightly", "24.02"]
-  print("Installing RAPIDS Nightly "+release[1])
-else:
-  release = ["rapidsai", "23.12"]
-  print("Installing RAPIDS Stable "+release[1])
+if ('P' not in gpu_name): # Currently supported GPU
+    if(sys.argv[1] == "nightly"):
+      release =  ["rapidsai-nightly", "24.04"]
+      print("Installing RAPIDS Nightly "+release[1])
+    else:
+      release = ["rapidsai", "24.02"]
+      print("Installing RAPIDS Stable "+release[1])
+else: # Pascal GPU Installation options (Not currently supported)
+  release =  ["rapidsai", "23.12"]
+  print(f"Installing RAPIDS compatible with your Pascal GPU, a {gpu_name}, "+release[1])
 
 pkg = "rapids"
 print("Starting the RAPIDS install on Colab.  This will take about 15 minutes.")

--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -80,7 +80,7 @@ for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
   else:
     print(line.rstrip())
 
-output = subprocess.Popen(["mamba install -y --prefix /usr/local -c "+release[0]+" -c nvidia -c conda-forge python=3.10 cuda-version=12.0 "+pkg+"="+release[1]+" llvmlite gcsfs openssl dask-sql"], shell=True, stderr=subprocess.STDOUT, 
+output = subprocess.Popen(["mamba install -y --prefix /usr/local -c "+release[0]+" -c conda-forge -c nvidia python=3.10 cuda-version=12.0 "+pkg+"="+release[1]+" llvmlite gcsfs openssl dask-sql"], shell=True, stderr=subprocess.STDOUT, 
     stdout=subprocess.PIPE)
 for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
   if(line == ""):

--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -63,7 +63,7 @@ if ('P' not in gpu_name): # Currently supported GPU
       release =  ["rapidsai-nightly", "24.04"]
       print("Installing RAPIDS Nightly "+release[1])
     else:
-      release = ["rapidsai", "24.02"]
+      release = ["rapidsai", "23.12"]
       print("Installing RAPIDS Stable "+release[1])
 else: # Pascal GPU Installation options (Not currently supported)
   release =  ["rapidsai", "23.12"]

--- a/colab/pip-install.py
+++ b/colab/pip-install.py
@@ -2,13 +2,46 @@ import os, sys, io
 import subprocess
 from pathlib import Path
 
-print('***********************************************************************')
-print('We will now install RAPIDS via pip! ')
-print('Please stand by, should be quick...')
-print('***********************************************************************')
-print()
 # Install RAPIDS -- we're doing this in one file, for now, due to ease of use
-rapids_version = "23.12.*"
+try: 
+  import pynvml
+except:
+  output = subprocess.Popen(["pip install pynvml"], shell=True, stderr=subprocess.STDOUT, 
+      stdout=subprocess.PIPE)
+  for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):
+    if(line == ""):
+      break
+    else:
+      print(line.rstrip())
+  import pynvml
+try:
+  pynvml.nvmlInit()
+except:
+  raise Exception("""
+                  Unfortunately you're in a Colab instance that doesn't have a GPU.
+
+                  Please make sure you've configured Colab to request a GPU Instance Type.
+               
+                  Go to 'Runtime -> Change Runtime Type --> under the Hardware Accelerator, select GPU', then try again."""
+  )
+gpu_name = pynvml.nvmlDeviceGetName(pynvml.nvmlDeviceGetHandleByIndex(0))
+rapids_version = "24.02.*"
+
+if ('P' not in gpu_name):
+  print('***********************************************************************')
+  print('Woo! Your instance has a '+ str(gpu_name)+' GPU!')
+  print(f'We will install the latest stable RAPIDS via pip {rapids_version}!  Please stand by, should be quick...')
+  print('***********************************************************************')
+  print()
+else:
+  print('***********************************************************************')
+  print('Hey! Your instance has a Pascal GPU, a '+ str(gpu_name)+'!')
+  print('We will install a compatible RAPIDS via pip (23.12)!  Please stand by, should be quick...')
+  print('***********************************************************************')
+  print()
+  rapids_version = "23.12.*"
+
+
 output = subprocess.Popen([f"pip install cudf-cu12=={rapids_version} cuml-cu12=={rapids_version} cugraph-cu12=={rapids_version} cuspatial-cu12=={rapids_version} cuproj-cu12=={rapids_version} cuxfilter-cu12=={rapids_version} cucim-cu12=={rapids_version} pylibraft-cu12=={rapids_version} raft-dask-cu12=={rapids_version} aiohttp --extra-index-url=https://pypi.nvidia.com"], shell=True, stderr=subprocess.STDOUT, 
     stdout=subprocess.PIPE)
 for line in io.TextIOWrapper(output.stdout, encoding="utf-8"):


### PR DESCRIPTION
Add logic to the conda and pip install code so that we can silently pin Pascal GPUs to 23.12 and allow newer GPUs to still install latest RAPIDS

- [x] conda version updated
- [x] pip version updated

Closes #94 