### PR TITLE
Fix installation of Treelite

### DIFF
--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -96,7 +96,7 @@ os.environ['NUMBAPRO_NVVM'] = '/usr/local/cuda/nvvm/lib64/libnvvm.so'
 os.environ['NUMBAPRO_LIBDEVICE'] = '/usr/local/cuda/nvvm/libdevice/'
 
 os.environ["CONDA_PREFIX"] = "/usr/local"
-for so in ['cudf', 'rmm', 'nccl', 'cuml', 'cugraph', 'xgboost', 'cuspatial', 'cupy', 'geos','geos_c']:
+for so in ['cudf', 'rmm', 'nccl', 'cuml', 'cugraph', 'xgboost', 'treelite', 'cuspatial', 'cupy', 'geos','geos_c']:
   fn = 'lib'+so+'.so'
   source_fn = '/usr/local/lib/'+fn
   dest_fn = '/usr/lib/'+fn


### PR DESCRIPTION
Currently, installing the nightly version of RAPIDS results in the following error:
```
TreeliteLibraryNotFound                   Traceback (most recent call last)
[<ipython-input-1-501aaa4ae771>](https://localhost:8080/#) in <cell line: 1>()
----> 1 import cudf, cuml, cugraph, cuspatial

7 frames
fil.pyx in init cuml.fil.fil()

[/usr/local/lib/python3.10/site-packages/treelite/libpath.py](https://localhost:8080/#) in find_lib_path()
     71             + " for installing Treelite."
     72         )
---> 73         raise TreeliteLibraryNotFound(msg)
     74     return lib_path

TreeliteLibraryNotFound: Cannot find Treelite Library in the candidate path.  List of candidates:
- /usr/local/lib/python3.10/site-packages/treelite/lib/libtreelite.so
- /usr/local/lib/python3.10/build/libtreelite.so
- /usr/lib/libtreelite.so
Treelite Python package path: /usr/local/lib/python3.10/site-packages/treelite
sys.prefix: /usr

See: https://treelite.readthedocs.io/en/latest/install.html for installing Treelite.
```

This pull request fixes the error by copying `libtreelite.so` to `/usr/lib/`, like other libraries such as `libxgboost.so`.