### PR TITLE
Colab: fix pip install for nightlies

### DIFF
--- a/colab/pip-install.py
+++ b/colab/pip-install.py
@@ -26,6 +26,9 @@ except:
   )
 gpu_name = pynvml.nvmlDeviceGetName(pynvml.nvmlDeviceGetHandleByIndex(0))
 
+LATEST_RAPIDS_VERSION = "24.8"
+NIGHTLY_RAPIDS_VERSION = "24.10"
+
 if(len(sys.argv)>=2):
   if(len(sys.argv[1])=="legacy"):
     rapids_version = "24.6.*"
@@ -33,15 +36,12 @@ if(len(sys.argv)>=2):
     output = subprocess.Popen([f"pip install cudf-cu12=={rapids_version} cuml-cu12=={rapids_version} cugraph-cu12=={rapids_version} cuspatial-cu12=={rapids_version} cuproj-cu12=={rapids_version} cuxfilter-cu12=={rapids_version} cucim-cu12=={rapids_version} pylibraft-cu12=={rapids_version} raft-dask-cu12=={rapids_version} nx-cugraph-cu12=={rapids_version} aiohttp --extra-index-url=https://pypi.nvidia.com"], shell=True, stderr=subprocess.STDOUT, 
       stdout=subprocess.PIPE)
   elif(sys.argv[1] == "latest"):
-    rapids_version = "24.8.*"
-    print("Installing RAPIDS Stable " + rapids_version)
-    output = subprocess.Popen([f"pip install cudf-cu12=={rapids_version} cuml-cu12=={rapids_version} cugraph-cu12=={rapids_version} cuspatial-cu12=={rapids_version} cuproj-cu12=={rapids_version} cuxfilter-cu12=={rapids_version} cucim-cu12=={rapids_version} pylibraft-cu12=={rapids_version} raft-dask-cu12=={rapids_version} nx-cugraph-cu12=={rapids_version} aiohttp --extra-index-url=https://pypi.nvidia.com"], shell=True, stderr=subprocess.STDOUT, 
+    print(f"Installing RAPIDS Stable {LATEST_RAPIDS_VERSION}.*")
+    output = subprocess.Popen([f"pip install cudf-cu12=={LATEST_RAPIDS_VERSION}.* cuml-cu12=={LATEST_RAPIDS_VERSION}.* cugraph-cu12=={LATEST_RAPIDS_VERSION}.* cuspatial-cu12=={rapids_version} cuproj-cu12=={rapids_version} cuxfilter-cu12=={rapids_version} cucim-cu12=={rapids_version} pylibraft-cu12=={rapids_version} raft-dask-cu12=={LATEST_RAPIDS_VERSION}.* nx-cugraph-cu12=={LATEST_RAPIDS_VERSION}.* aiohttp --extra-index-url=https://pypi.nvidia.com"], shell=True, stderr=subprocess.STDOUT, 
       stdout=subprocess.PIPE)
   elif(sys.argv[1] == "nightlies"):
-    rapids_version = "24.10.*"
-    print("Installing RAPIDS " + rapids_version)
-    rapids_version = "24.10"
-    output = subprocess.Popen([f'pip install "cudf-cu12>={rapids_version}.0a0,<=24.8" "cuml-cu12>={rapids_version}.0a0,<=24.8" "cugraph-cu12>={rapids_version}.0a0,<=24.8" "cuspatial-cu12>={rapids_version}.0a0,<=24.8" "cuproj-cu12>={rapids_version}.0a0,<=24.8" "cuxfilter-cu12>={rapids_version}.0a0,<=24.8" "cucim-cu12>={rapids_version}.0a0,<=24.8" "pylibraft-cu12>={rapids_version}.0a0,<=24.8" "raft-dask-cu12>={rapids_version}.0a0,<=24.8" "nx-cugraph-cu12>={rapids_version}.0a0,<=24.8" aiohttp --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple'], shell=True, stderr=subprocess.STDOUT, 
+    print(f"Installing RAPIDS {NIGHTLY_RAPIDS_VERSION}.*")
+    output = subprocess.Popen([f'pip install "cudf-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cuml-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cugraph-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cuspatial-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cuproj-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cuxfilter-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cucim-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "pylibraft-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a" "raft-dask-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "nx-cugraph-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" aiohttp --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple'], shell=True, stderr=subprocess.STDOUT, 
       stdout=subprocess.PIPE)
   else:
     rapids_version = "24.8.*"


### PR DESCRIPTION
Fixes #104

While testing the RAPIDS deployment docs (https://github.com/rapidsai/deployment/issues/434), I tried to follow the Colab instructions for installing RAPIDS libraries with `pip`.

Found that the script that does that is broken... it has a hard-coded upper bound pin in the set of requirements generated when you ask for nightlies to be installed, resulting in impossible requirements like `cudf>=24.10.0a0,<=24.8`.

This fixes that, and puts the "latest" and "nightly" versions into module-level constants to make such mistakes less likely in the future.

## Notes for Reviewers

### How I tested this

Opened the RAPIDS pip colab notebook at https://nvda.ws/3XEO6hK.

Pointed the install lines at my branch here:

```ipython
!git clone https://github.com/jameslamb/rapidsai-csp-utils.git --branch fix/pip-install
!python rapidsai-csp-utils/colab/pip-install.py nightlies
```

Ran the rest of the notebook and saw it successfully install the expected versions of libraries.

```ipython
!pip freeze | grep -E '.*cu.*'
```

<img width="386" alt="image" src="https://github.com/user-attachments/assets/433c4555-05f7-4e29-8650-ae988d62f25b">

~Importing `cuml` failed, will open a separate issue for that and link it here.~ Nevermind, just a mix of versions. Everything ran successfully in a clean session!