### PR TITLE
update latest and nightly rapids versions for Colab

### DIFF
--- a/colab/pip-install.py
+++ b/colab/pip-install.py
@@ -30,6 +30,7 @@ LATEST_RAPIDS_VERSION = "25.10"
 NIGHTLY_RAPIDS_VERSION = "25.12"
 LEGACY_RAPIDS_VERSION = "25.08"
 COLAB_RAPIDS_VERSION = "25.10"
+CUSPATIAL_RAPIDS_VERSION = 25.04" # WARNING, this courtesy version is unsupported and can break at any time!  Please use the RAPIDS 25.04 docker container on a GPU instance, like brev.nvidia.com, if this starts to fail
 
 if(len(sys.argv)>=2):
   if(len(sys.argv[1])=="legacy"):
@@ -45,13 +46,18 @@ if(len(sys.argv)>=2):
     print(f"Installing RAPIDS {NIGHTLY_RAPIDS_VERSION}.*")
     output = subprocess.Popen([f'pip install "cudf-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cuml-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cugraph-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cuxfilter-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "cucim-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "pylibraft-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a" "raft-dask-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" "nx-cugraph-cu12=={NIGHTLY_RAPIDS_VERSION}.*,>=0.0.0a0" aiohttp --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple'], shell=True, stderr=subprocess.STDOUT,
       stdout=subprocess.PIPE)
+  elif(sys.argv[1] == "cuspatial"):
+    rapids_version = CUSPATIAL_RAPIDS_VERSION
+    print("Attempting to install RAPIDS cuSpatial compatible " + rapids_version + " libraries.  This is an unsupported version")
+    output = subprocess.Popen([f"pip install cudf-cu12=={rapids_version}.* cuml-cu12=={rapids_version}.* cugraph-cu12=={rapids_version}.* cuspatial-cu12=={rapids_version}.* cuxfilter-cu12=={rapids_version}.* cucim-cu12=={rapids_version}.* pylibraft-cu12=={rapids_version}.* raft-dask-cu12=={rapids_version}.* nx-cugraph-cu12=={rapids_version}.* aiohttp --extra-index-url=https://pypi.nvidia.com"], shell=True, stderr=subprocess.STDOUT,
+      stdout=subprocess.PIPE)
   else:
-    rapids_version = LATEST_RAPIDS_VERSION
-    print("Installing RAPIDS Stable " + rapids_version)
+    rapids_version = COLAB_RAPIDS_VERSION
+    print("Installing RAPIDS remaining " + rapids_version + " libraries")
     output = subprocess.Popen([f"pip install cudf-cu12=={rapids_version}.* cuml-cu12=={rapids_version}.* cugraph-cu12=={rapids_version}.* cuxfilter-cu12=={rapids_version}.* cucim-cu12=={rapids_version}.* pylibraft-cu12=={rapids_version}.* raft-dask-cu12=={rapids_version}.* nx-cugraph-cu12=={rapids_version}.* aiohttp --extra-index-url=https://pypi.nvidia.com"], shell=True, stderr=subprocess.STDOUT,
       stdout=subprocess.PIPE)
 else:
-  rapids_version = LATEST_RAPIDS_VERSION
+  rapids_version = COLAB_RAPIDS_VERSION
   print("Installing RAPIDS remaining " + rapids_version + " libraries")
   output = subprocess.Popen([f"uv pip install --system cudf-cu12=={rapids_version}.* cuml-cu12=={rapids_version}.* cugraph-cu12=={rapids_version}.* cuxfilter-cu12=={rapids_version}.* cucim-cu12=={rapids_version}.* pylibraft-cu12=={rapids_version}.* raft-dask-cu12=={rapids_version}.* nx-cugraph-cu12=={rapids_version}.* aiohttp --extra-index-url=https://pypi.nvidia.com"], shell=True, stderr=subprocess.STDOUT,
     stdout=subprocess.PIPE)


### PR DESCRIPTION
Updating Colab pip install script to use the latest stable and nightly versions of RAPIDS. 

Not sure how `legacy` is used but if this should also be bumped please let me know, or feel free to add. 

Should resolve the versioning component of https://github.com/rapidsai/deployment/issues/629

cc @taureandyernv 