### PR TITLE
Revert "udpate rapids version for colab install 26.06"

### DIFF
--- a/colab/pip-install.py
+++ b/colab/pip-install.py
@@ -26,8 +26,8 @@ except:
   )
 gpu_name = pynvml.nvmlDeviceGetName(pynvml.nvmlDeviceGetHandleByIndex(0))
 
-LATEST_RAPIDS_VERSION = "26.06"
-NIGHTLY_RAPIDS_VERSION = "26.08"
+LATEST_RAPIDS_VERSION = "26.04"
+NIGHTLY_RAPIDS_VERSION = "26.06"
 LEGACY_RAPIDS_VERSION = "26.02"
 COLAB_RAPIDS_VERSION = "26.02"
 CUSPATIAL_RAPIDS_VERSION = "25.04" # WARNING, this courtesy version is unsupported and can break at any time!  Please use the RAPIDS 25.04 docker container on a GPU instance, like brev.nvidia.com, if this starts to fail


### PR DESCRIPTION
Reverts rapidsai-community/rapidsai-csp-utils#134

While testing this, I was not able to install rapids 26.6 in colab, using the nightlies script, 

Error:

```
Installing RAPIDS 26.06.*
Looking in indexes: https://pypi.org/simple, https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
Collecting cudf-cu12==26.06.*,>=0.0.0a0
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/cudf-cu12/26.6.0a383/cudf_cu12-26.6.0a383-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (2.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.7/2.7 MB 2.0 MB/s eta 0:00:00
Collecting cuml-cu12==26.06.*,>=0.0.0a0
  WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))': /65529d7ed17d91b7f8b76f5e/6a1dab7680853ce689b268c6?response-content-disposition=attachment%3B%20filename%3D%22cuml_cu12-26.6.0a165-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl%22%3B%20filename%2A%3DUTF-8%27%27cuml_cu12-26.6.0a165-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAWUI46DZFNQ2RHJLM%2F20260601%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260601T201518Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEEwaCXVzLWVhc3QtMSJIMEYCIQC9xycBysy5Ek10bxbYsZzbLgaGOt9yeJ1ZnnACu5E0xAIhAL5uyc5y%2FQXLgkd%2BAYeBBk9JpfyyN2t5urxARUtyZtgXKoAFCBUQABoMNDU1ODY0MDk4Mzc4Igwjbr%2Fb%2FndNbvmxOscq3QRkc%2F9pEXbxZ%2B3vHEBFVTF2bRrqM7lrbWk0gf6zfkxtn9AoivImY8ReUB8Tiy%2BvHNyP5bwqSQp9B5bQotOhAphngkHf4vwfztdmJqaJ82mdpar0olza%2FaVFsoNr%2B%2FG5cboL57bsilcBxKddXMFAQtd2qwU7WOw6UieW%2BId1UzEH1xchSq0B5Yv1SOajUVqkpSLwAxDLfroeFjMGKjAGlGXRqDlz7zK5EyTdcgsCtzf0FpRN8V7DD9aYU1BolMnOcDz7X%2FxdvDBCf0UDAjO%2FCs2LdR9kJmH%2BS5FaYQOEmNTz9mkllXijSdR7hOArAk5So97fQeXf%2BwTLrM0NbKDs5Hu6a8LyUUBeD6jMPVkIF1u7b%2BKzZQ9GolCyGyjvzbv1oYkiOt6jti0NfS%2BYHKi4v%2BnS%2ByZ%2F3TvN7D33z2RtkT%2BZDNKiKOUrMdM%2FlhYZPLTFx3jpcfqoKIUIl341Kij6zfegn7p1VtpcWFScktdMj46hbkpEtehMGQkQ1x91gkyBUg504PdU1Q1k5KnltA4HdM%2FlXWjo0binlgyEZQoSF%2BnfglHpCEQFv%2Butdjb%2BrruvChv4chWOLdrhTJF6DEdeBgOHuRWTajaIhGt1NvFzs8paYag5J1tIwktKPG8LfmEqWCpPFWgNVfXBTJAQZxNWDIA6%2BBCCK4j%2Bg32D8rMqzMoXDkBxDJPAgeYdjm%2B1BzRmPftdH5AwsEfOsy4Zbmee77Zn5zbkS%2FsUZeZI1wixT4bGmXi%2BjRVmM%2BU%2FvIOud39XyKY%2BKZ5E8HWZ97u28qlNh8Ph26ikSUO1nTtJWeO9SjD6yvfQBjqXAUjqX%2BL8jFDdWJwiBvtUXO2GGLdwblCS9KUS%2FqgowuyhBi%2FtLodeWOI%2BHqSguYzPvvRe8mnkAjeHGNSOsUSp%2BKOM5VqX3zB%2FGtnRNc89IHAFmwcluDFRPMrv4cyjLBE7zujZo65kw64YuKsJp5I12hf4pdqWoP19CyFYpFzaDC3i0XkcOgSqxa4DucKzfxZ1lqSOhVFqRNw%3D&X-Amz-Signature=cccb41ef57463d7137ee050211329c65585dd4c66272f49d4e75995530e5e517
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/cuml-cu12/26.6.0a165/cuml_cu12-26.6.0a165-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (5.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.6/5.6 MB 3.4 MB/s eta 0:00:00
Collecting cugraph-cu12==26.06.*,>=0.0.0a0
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/cugraph-cu12/26.6.0a56/cugraph_cu12-26.6.0a56-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (2.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.0/2.0 MB 55.3 MB/s eta 0:00:00
Collecting cuxfilter-cu12==26.06.*,>=0.0.0a0
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/cuxfilter-cu12/26.6.0a11/cuxfilter_cu12-26.6.0a11-py3-none-manylinux_2_28_aarch64.manylinux_2_28_x86_64.whl (91 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 91.4/91.4 kB 9.7 MB/s eta 0:00:00
Collecting cucim-cu12==26.06.*,>=0.0.0a0
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/cucim-cu12/26.6.0a38/cucim_cu12-26.6.0a38-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (16.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.9/16.9 MB 12.5 MB/s eta 0:00:00
Collecting pylibraft-cu12==26.06.*,>=0.0.0a
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/pylibraft-cu12/26.6.0a37/pylibraft_cu12-26.6.0a37-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (933 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 933.5/933.5 kB 809.2 kB/s eta 0:00:00
Collecting raft-dask-cu12==26.06.*,>=0.0.0a0
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/raft-dask-cu12/26.6.0a37/raft_dask_cu12-26.6.0a37-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (1.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 4.8 MB/s eta 0:00:00
Collecting nx-cugraph-cu12==26.06.*,>=0.0.0a0
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/nx-cugraph-cu12/26.6.0a11/nx_cugraph_cu12-26.6.0a11-py3-none-any.whl (153 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 153.4/153.4 kB 13.1 MB/s eta 0:00:00
Requirement already satisfied: aiohttp in /usr/local/lib/python3.12/dist-packages (3.13.5)
Requirement already satisfied: cachetools in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (6.2.6)
Requirement already satisfied: cuda-python<13.0,>=12.9.2 in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (12.9.6)
Requirement already satisfied: cuda-toolkit==12.* in /usr/local/lib/python3.12/dist-packages (from cuda-toolkit[nvcc,nvrtc]==12.*->cudf-cu12==26.06.*,>=0.0.0a0) (12.8.1)
Requirement already satisfied: cupy-cuda12x!=14.0.0,!=14.1.0,>=13.6.0 in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (14.0.1)
Requirement already satisfied: fsspec>=0.6.0 in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (2025.3.0)
Collecting libcudf-cu12==26.6.*,>=0.0.0a0 (from cudf-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/libcudf-cu12/26.6.0a383/libcudf_cu12-26.6.0a383-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (717.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 717.3/717.3 MB 2.5 MB/s eta 0:00:00
Requirement already satisfied: numba-cuda<0.29.0,>=0.22.2 in /usr/local/lib/python3.12/dist-packages (from numba-cuda[cu12]<0.29.0,>=0.22.2->cudf-cu12==26.06.*,>=0.0.0a0) (0.22.2)
Requirement already satisfied: numba<0.65.0,>=0.60.0 in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (0.60.0)
Requirement already satisfied: numpy<3.0,>=1.26 in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (2.0.2)
Requirement already satisfied: nvtx>=0.2.1 in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (0.2.15)
Requirement already satisfied: packaging in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (26.2)
Requirement already satisfied: pandas<2.4.0,>=2.0 in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (2.2.2)
Collecting pyarrow<24,>=19.0.0 (from cudf-cu12==26.06.*,>=0.0.0a0)
  Downloading pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (3.1 kB)
Collecting pylibcudf-cu12==26.6.*,>=0.0.0a0 (from pylibcudf-cu12[pyarrow]==26.6.*,>=0.0.0a0->cudf-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/pylibcudf-cu12/26.6.0a383/pylibcudf_cu12-26.6.0a383-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (8.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.3/8.3 MB 4.0 MB/s eta 0:00:00
Requirement already satisfied: rich in /usr/local/lib/python3.12/dist-packages (from cudf-cu12==26.06.*,>=0.0.0a0) (13.9.4)
Collecting rmm-cu12==26.6.*,>=0.0.0a0 (from cudf-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/rmm-cu12/26.6.0a98/rmm_cu12-26.6.0a98-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (946 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 946.5/946.5 kB 40.6 MB/s eta 0:00:00
Requirement already satisfied: joblib>=0.11 in /usr/local/lib/python3.12/dist-packages (from cuml-cu12==26.06.*,>=0.0.0a0) (1.5.3)
Collecting libcuml-cu12==26.6.*,>=0.0.0a0 (from cuml-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/libcuml-cu12/26.6.0a165/libcuml_cu12-26.6.0a165-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (380.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 380.0/380.0 MB 4.2 MB/s eta 0:00:00
Collecting nvforest-cu12==26.6.*,>=0.0.0a0 (from cuml-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/nvforest-cu12/26.6.0a32/nvforest_cu12-26.6.0a32-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (935 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 935.4/935.4 kB 811.4 kB/s eta 0:00:00
Collecting nvidia-nvjitlink-cu12<13,>=12.9 (from cuml-cu12==26.06.*,>=0.0.0a0)
  Downloading nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl.metadata (1.7 kB)
Requirement already satisfied: scikit-learn>=1.5 in /usr/local/lib/python3.12/dist-packages (from cuml-cu12==26.06.*,>=0.0.0a0) (1.6.1)
Requirement already satisfied: scipy>=1.14.0 in /usr/local/lib/python3.12/dist-packages (from cuml-cu12==26.06.*,>=0.0.0a0) (1.16.3)
Requirement already satisfied: treelite<5.0.0,>=4.7.0 in /usr/local/lib/python3.12/dist-packages (from cuml-cu12==26.06.*,>=0.0.0a0) (4.7.0)
Collecting dask-cuda==26.6.*,>=0.0.0a0 (from dask-cuda[cu12]==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/dask-cuda/26.6.0a14/dask_cuda-26.6.0a14-py3-none-manylinux_2_28_aarch64.manylinux_2_28_x86_64.whl (113 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 113.6/113.6 kB 228.8 kB/s eta 0:00:00
Collecting dask-cudf-cu12==26.6.*,>=0.0.0a0 (from cugraph-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/dask-cudf-cu12/26.6.0a383/dask_cudf_cu12-26.6.0a383-py3-none-any.whl (51 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 51.2/51.2 kB 3.7 MB/s eta 0:00:00
Collecting libcugraph-cu12==26.6.*,>=0.0.0a0 (from cugraph-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/libcugraph-cu12/26.6.0a56/libcugraph_cu12-26.6.0a56-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (1343.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/1.3 GB 539.8 kB/s eta 0:00:00
Collecting pylibcugraph-cu12==26.6.*,>=0.0.0a0 (from cugraph-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/pylibcugraph-cu12/26.6.0a56/pylibcugraph_cu12-26.6.0a56-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (1.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.9/1.9 MB 1.4 MB/s eta 0:00:00
Collecting rapids-dask-dependency==26.6.*,>=0.0.0a0 (from cugraph-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/rapids-dask-dependency/26.6.0a4/rapids_dask_dependency-26.6.0a4-py3-none-any.whl (10 kB)
Collecting ucxx-cu12==0.50.*,>=0.0.0a0 (from cugraph-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ucxx-cu12/0.50.0a44/ucxx_cu12-0.50.0a44-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (724 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 724.4/724.4 kB 54.1 MB/s eta 0:00:00
Collecting bokeh<=3.6.3,>=3.1 (from cuxfilter-cu12==26.06.*,>=0.0.0a0)
  Downloading bokeh-3.6.3-py3-none-any.whl.metadata (12 kB)
Requirement already satisfied: certifi>=2026.1.4 in /usr/local/lib/python3.12/dist-packages (from cuxfilter-cu12==26.06.*,>=0.0.0a0) (2026.5.20)
Collecting datashader>=0.15 (from cuxfilter-cu12==26.06.*,>=0.0.0a0)
  Downloading datashader-0.19.1-py3-none-any.whl.metadata (8.0 kB)
Requirement already satisfied: geopandas>=0.11.0 in /usr/local/lib/python3.12/dist-packages (from cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.1.3)
Collecting holoviews<1.21.0,>=1.16.0 (from cuxfilter-cu12==26.06.*,>=0.0.0a0)
  Downloading holoviews-1.20.2-py3-none-any.whl.metadata (9.9 kB)
Collecting jupyter-server-proxy (from cuxfilter-cu12==26.06.*,>=0.0.0a0)
  Downloading jupyter_server_proxy-4.5.0-py3-none-any.whl.metadata (8.8 kB)
Requirement already satisfied: panel>=1.0 in /usr/local/lib/python3.12/dist-packages (from cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.9.0)
Requirement already satisfied: requests in /usr/local/lib/python3.12/dist-packages (from cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.32.4)
Requirement already satisfied: shapely in /usr/local/lib/python3.12/dist-packages (from cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.1.2)
Requirement already satisfied: click in /usr/local/lib/python3.12/dist-packages (from cucim-cu12==26.06.*,>=0.0.0a0) (8.4.0)
Requirement already satisfied: lazy-loader>=0.4 in /usr/local/lib/python3.12/dist-packages (from cucim-cu12==26.06.*,>=0.0.0a0) (0.5)
Collecting nvidia-nvimgcodec-cu12<0.9.0,>=0.8.0 (from cucim-cu12==26.06.*,>=0.0.0a0)
  Downloading nvidia_nvimgcodec_cu12-0.8.0.22-py3-none-manylinux_2_28_x86_64.whl.metadata (1.9 kB)
Requirement already satisfied: scikit-image<0.27.0,>=0.23.2 in /usr/local/lib/python3.12/dist-packages (from cucim-cu12==26.06.*,>=0.0.0a0) (0.25.2)
Collecting libraft-cu12==26.6.*,>=0.0.0a0 (from pylibraft-cu12==26.06.*,>=0.0.0a)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/libraft-cu12/26.6.0a37/libraft_cu12-26.6.0a37-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (22.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 22.6/22.6 MB 10.8 MB/s eta 0:00:00
Collecting distributed-ucxx-cu12==0.50.*,>=0.0.0a0 (from raft-dask-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/distributed-ucxx-cu12/0.50.0a44/distributed_ucxx_cu12-0.50.0a44-py3-none-manylinux_2_28_aarch64.manylinux_2_28_x86_64.whl (32 kB)
Requirement already satisfied: nvidia-nccl-cu12>=2.19 in /usr/local/lib/python3.12/dist-packages (from raft-dask-cu12==26.06.*,>=0.0.0a0) (2.28.9)
Requirement already satisfied: networkx>=3.2 in /usr/local/lib/python3.12/dist-packages (from nx-cugraph-cu12==26.06.*,>=0.0.0a0) (3.6.1)
Requirement already satisfied: nvidia-cublas-cu12==12.8.4.1.* in /usr/local/lib/python3.12/dist-packages (from cuda-toolkit[cublas,cufft,curand,cusolver,cusparse]==12.*->cuml-cu12==26.06.*,>=0.0.0a0) (12.8.4.1)
Requirement already satisfied: nvidia-cufft-cu12==11.3.3.83.* in /usr/local/lib/python3.12/dist-packages (from cuda-toolkit[cublas,cufft,curand,cusolver,cusparse]==12.*->cuml-cu12==26.06.*,>=0.0.0a0) (11.3.3.83)
Requirement already satisfied: nvidia-curand-cu12==10.3.9.90.* in /usr/local/lib/python3.12/dist-packages (from cuda-toolkit[cublas,cufft,curand,cusolver,cusparse]==12.*->cuml-cu12==26.06.*,>=0.0.0a0) (10.3.9.90)
Requirement already satisfied: nvidia-cusolver-cu12==11.7.3.90.* in /usr/local/lib/python3.12/dist-packages (from cuda-toolkit[cublas,cufft,curand,cusolver,cusparse]==12.*->cuml-cu12==26.06.*,>=0.0.0a0) (11.7.3.90)
Requirement already satisfied: nvidia-cusparse-cu12==12.5.8.93.* in /usr/local/lib/python3.12/dist-packages (from cuda-toolkit[cublas,cufft,curand,cusolver,cusparse]==12.*->cuml-cu12==26.06.*,>=0.0.0a0) (12.5.8.93)
Requirement already satisfied: nvidia-cuda-nvcc-cu12==12.8.93.* in /usr/local/lib/python3.12/dist-packages (from cuda-toolkit[nvcc,nvrtc]==12.*->cudf-cu12==26.06.*,>=0.0.0a0) (12.8.93)
Requirement already satisfied: nvidia-cuda-nvrtc-cu12==12.8.93.* in /usr/local/lib/python3.12/dist-packages (from cuda-toolkit[nvcc,nvrtc]==12.*->cudf-cu12==26.06.*,>=0.0.0a0) (12.8.93)
Requirement already satisfied: cuda-core>=0.3.2 in /usr/local/lib/python3.12/dist-packages (from dask-cuda==26.6.*,>=0.0.0a0->dask-cuda[cu12]==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (0.3.2)
Requirement already satisfied: nvidia-ml-py>=12 in /usr/local/lib/python3.12/dist-packages (from dask-cuda==26.6.*,>=0.0.0a0->dask-cuda[cu12]==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (13.595.45)
Requirement already satisfied: zict>=2.0.0 in /usr/local/lib/python3.12/dist-packages (from dask-cuda==26.6.*,>=0.0.0a0->dask-cuda[cu12]==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (3.0.0)
Requirement already satisfied: pyyaml>=6 in /usr/local/lib/python3.12/dist-packages (from distributed-ucxx-cu12==0.50.*,>=0.0.0a0->raft-dask-cu12==26.06.*,>=0.0.0a0) (6.0.3)
Collecting libkvikio-cu12==26.6.*,>=0.0.0a0 (from libcudf-cu12==26.6.*,>=0.0.0a0->cudf-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/libkvikio-cu12/26.6.0a18/libkvikio_cu12-26.6.0a18-py3-none-manylinux_2_28_x86_64.whl (2.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.4/2.4 MB 33.5 MB/s eta 0:00:00
Collecting librmm-cu12==26.6.*,>=0.0.0a0 (from libcudf-cu12==26.6.*,>=0.0.0a0->cudf-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/librmm-cu12/26.6.0a98/librmm_cu12-26.6.0a98-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (4.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.5/4.5 MB 17.6 MB/s eta 0:00:00
Collecting nvidia-libnvcomp-cu12==5.2.0.13 (from libcudf-cu12==26.6.*,>=0.0.0a0->cudf-cu12==26.06.*,>=0.0.0a0)
  Downloading nvidia_libnvcomp_cu12-5.2.0.13-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl.metadata (718 bytes)
Requirement already satisfied: rapids-logger==0.2.*,>=0.0.0a0 in /usr/local/lib/python3.12/dist-packages (from libcudf-cu12==26.6.*,>=0.0.0a0->cudf-cu12==26.06.*,>=0.0.0a0) (0.2.3)
Collecting libcuvs-cu12==26.6.*,>=0.0.0a0 (from libcugraph-cu12==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/libcuvs-cu12/26.6.0a127/libcuvs_cu12-26.6.0a127-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (352.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 352.5/352.5 MB 4.0 MB/s eta 0:00:00
Collecting libnvforest-cu12==26.6.*,>=0.0.0a0 (from libcuml-cu12==26.6.*,>=0.0.0a0->cuml-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/libnvforest-cu12/26.6.0a32/libnvforest_cu12-26.6.0a32-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (81.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 81.4/81.4 MB 6.7 MB/s eta 0:00:00
Requirement already satisfied: dask<2026.1.2,>=2026.1.1 in /usr/local/lib/python3.12/dist-packages (from rapids-dask-dependency==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (2026.1.1)
Requirement already satisfied: distributed<2026.1.2,>=2026.1.1 in /usr/local/lib/python3.12/dist-packages (from rapids-dask-dependency==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (2026.1.1)
Collecting libucxx-cu12==0.50.*,>=0.0.0a0 (from ucxx-cu12==0.50.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0)
  Downloading https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/libucxx-cu12/0.50.0a44/libucxx_cu12-0.50.0a44-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (571 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 571.7/571.7 kB 17.2 MB/s eta 0:00:00
Requirement already satisfied: libucx-cu12<1.20,>=1.18.0 in /usr/local/lib/python3.12/dist-packages (from libucxx-cu12==0.50.*,>=0.0.0a0->ucxx-cu12==0.50.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (1.19.0)
Requirement already satisfied: aiohappyeyeballs>=2.5.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp) (2.6.2)
Requirement already satisfied: aiosignal>=1.4.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp) (1.4.0)
Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp) (26.1.0)
Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.12/dist-packages (from aiohttp) (1.8.0)
Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.12/dist-packages (from aiohttp) (6.7.1)
Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp) (0.5.2)
Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp) (1.24.2)
Requirement already satisfied: typing-extensions>=4.2 in /usr/local/lib/python3.12/dist-packages (from aiosignal>=1.4.0->aiohttp) (4.15.0)
Requirement already satisfied: Jinja2>=2.9 in /usr/local/lib/python3.12/dist-packages (from bokeh<=3.6.3,>=3.1->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.1.6)
Requirement already satisfied: contourpy>=1.2 in /usr/local/lib/python3.12/dist-packages (from bokeh<=3.6.3,>=3.1->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.3.3)
Requirement already satisfied: pillow>=7.1.0 in /usr/local/lib/python3.12/dist-packages (from bokeh<=3.6.3,>=3.1->cuxfilter-cu12==26.06.*,>=0.0.0a0) (11.3.0)
Requirement already satisfied: tornado>=6.2 in /usr/local/lib/python3.12/dist-packages (from bokeh<=3.6.3,>=3.1->cuxfilter-cu12==26.06.*,>=0.0.0a0) (6.5.1)
Requirement already satisfied: xyzservices>=2021.09.1 in /usr/local/lib/python3.12/dist-packages (from bokeh<=3.6.3,>=3.1->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2026.3.0)
Requirement already satisfied: cuda-bindings~=12.9.6 in /usr/local/lib/python3.12/dist-packages (from cuda-python<13.0,>=12.9.2->cudf-cu12==26.06.*,>=0.0.0a0) (12.9.6)
Requirement already satisfied: cuda-pathfinder==1.*,>=1.3.3 in /usr/local/lib/python3.12/dist-packages (from cupy-cuda12x!=14.0.0,!=14.1.0,>=13.6.0->cudf-cu12==26.06.*,>=0.0.0a0) (1.5.4)
Requirement already satisfied: colorcet in /usr/local/lib/python3.12/dist-packages (from datashader>=0.15->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.2.1)
Requirement already satisfied: multipledispatch in /usr/local/lib/python3.12/dist-packages (from datashader>=0.15->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.0.0)
Requirement already satisfied: param in /usr/local/lib/python3.12/dist-packages (from datashader>=0.15->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.4.0)
Collecting pyct (from datashader>=0.15->cuxfilter-cu12==26.06.*,>=0.0.0a0)
  Downloading pyct-0.6.0-py3-none-any.whl.metadata (7.2 kB)
Requirement already satisfied: toolz in /usr/local/lib/python3.12/dist-packages (from datashader>=0.15->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.12.1)
Requirement already satisfied: xarray in /usr/local/lib/python3.12/dist-packages (from datashader>=0.15->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2025.12.0)
Requirement already satisfied: pyogrio>=0.7.2 in /usr/local/lib/python3.12/dist-packages (from geopandas>=0.11.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.12.1)
Requirement already satisfied: pyproj>=3.5.0 in /usr/local/lib/python3.12/dist-packages (from geopandas>=0.11.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.7.2)
Requirement already satisfied: pyviz-comms>=2.1 in /usr/local/lib/python3.12/dist-packages (from holoviews<1.21.0,>=1.16.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.0.6)
Requirement already satisfied: llvmlite<0.44,>=0.43.0dev0 in /usr/local/lib/python3.12/dist-packages (from numba<0.65.0,>=0.60.0->cudf-cu12==26.06.*,>=0.0.0a0) (0.43.0)
Requirement already satisfied: nvidia-cuda-runtime-cu12 in /usr/local/lib/python3.12/dist-packages (from numba-cuda[cu12]<0.29.0,>=0.22.2->cudf-cu12==26.06.*,>=0.0.0a0) (12.8.90)
Requirement already satisfied: nvidia-cuda-cccl-cu12 in /usr/local/lib/python3.12/dist-packages (from numba-cuda[cu12]<0.29.0,>=0.22.2->cudf-cu12==26.06.*,>=0.0.0a0) (12.9.27)
Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.12/dist-packages (from pandas<2.4.0,>=2.0->cudf-cu12==26.06.*,>=0.0.0a0) (2.9.0.post0)
Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.12/dist-packages (from pandas<2.4.0,>=2.0->cudf-cu12==26.06.*,>=0.0.0a0) (2025.2)
Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.12/dist-packages (from pandas<2.4.0,>=2.0->cudf-cu12==26.06.*,>=0.0.0a0) (2026.2)
INFO: pip is looking at multiple versions of panel to determine which version is compatible with other requirements. This could take a while.
Collecting panel>=1.0 (from cuxfilter-cu12==26.06.*,>=0.0.0a0)
  Downloading panel-1.9.3-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.9.2-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.9.1-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.8.10-py3-none-any.whl.metadata (15 kB)
Requirement already satisfied: bleach in /usr/local/lib/python3.12/dist-packages (from panel>=1.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (6.3.0)
  Downloading panel-1.8.9-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.8.8-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.8.7-py3-none-any.whl.metadata (15 kB)
INFO: pip is still looking at multiple versions of panel to determine which version is compatible with other requirements. This could take a while.
  Downloading panel-1.8.6-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.8.5-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.8.4-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.8.3-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.8.2-py3-none-any.whl.metadata (15 kB)
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
  Downloading panel-1.8.1-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.8.0-py3-none-any.whl.metadata (15 kB)
  Downloading panel-1.7.5-py3-none-any.whl.metadata (15 kB)
Requirement already satisfied: linkify-it-py in /usr/local/lib/python3.12/dist-packages (from panel>=1.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.1.0)
Requirement already satisfied: markdown in /usr/local/lib/python3.12/dist-packages (from panel>=1.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.10.2)
Requirement already satisfied: markdown-it-py in /usr/local/lib/python3.12/dist-packages (from panel>=1.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (4.2.0)
Requirement already satisfied: mdit-py-plugins in /usr/local/lib/python3.12/dist-packages (from panel>=1.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.6.1)
Requirement already satisfied: tqdm in /usr/local/lib/python3.12/dist-packages (from panel>=1.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (4.67.3)
Requirement already satisfied: imageio!=2.35.0,>=2.33 in /usr/local/lib/python3.12/dist-packages (from scikit-image<0.27.0,>=0.23.2->cucim-cu12==26.06.*,>=0.0.0a0) (2.37.3)
Requirement already satisfied: tifffile>=2022.8.12 in /usr/local/lib/python3.12/dist-packages (from scikit-image<0.27.0,>=0.23.2->cucim-cu12==26.06.*,>=0.0.0a0) (2026.4.11)
Requirement already satisfied: threadpoolctl>=3.1.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn>=1.5->cuml-cu12==26.06.*,>=0.0.0a0) (3.6.0)
Requirement already satisfied: idna>=2.0 in /usr/local/lib/python3.12/dist-packages (from yarl<2.0,>=1.17.0->aiohttp) (3.15)
Requirement already satisfied: jupyter-server>=1.24.0 in /usr/local/lib/python3.12/dist-packages (from jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.14.0)
Collecting simpervisor>=1.0.0 (from jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0)
  Downloading simpervisor-1.0.0-py3-none-any.whl.metadata (4.3 kB)
Requirement already satisfied: traitlets>=5.1.0 in /usr/local/lib/python3.12/dist-packages (from jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (5.7.1)
Requirement already satisfied: charset_normalizer<4,>=2 in /usr/local/lib/python3.12/dist-packages (from requests->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.4.7)
Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.12/dist-packages (from requests->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.5.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /usr/local/lib/python3.12/dist-packages (from rich->cudf-cu12==26.06.*,>=0.0.0a0) (2.20.0)
Collecting nvidia-nvfatbin-cu12 (from cuda-bindings[all]==12.*; extra == "cu12"->cuda-core[cu12]>=0.3.2; extra == "cu12"->dask-cuda[cu12]==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0)
  Downloading nvidia_nvfatbin_cu12-12.9.82-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl.metadata (1.7 kB)
Requirement already satisfied: nvidia-cufile-cu12 in /usr/local/lib/python3.12/dist-packages (from cuda-bindings[all]==12.*; extra == "cu12"->cuda-core[cu12]>=0.3.2; extra == "cu12"->dask-cuda[cu12]==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (1.13.1.3)
Requirement already satisfied: cloudpickle>=3.0.0 in /usr/local/lib/python3.12/dist-packages (from dask<2026.1.2,>=2026.1.1->rapids-dask-dependency==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (3.1.2)
Requirement already satisfied: partd>=1.4.0 in /usr/local/lib/python3.12/dist-packages (from dask<2026.1.2,>=2026.1.1->rapids-dask-dependency==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (1.4.2)
Requirement already satisfied: locket>=1.0.0 in /usr/local/lib/python3.12/dist-packages (from distributed<2026.1.2,>=2026.1.1->rapids-dask-dependency==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (1.0.0)
Requirement already satisfied: msgpack>=1.0.2 in /usr/local/lib/python3.12/dist-packages (from distributed<2026.1.2,>=2026.1.1->rapids-dask-dependency==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (1.1.2)
Requirement already satisfied: psutil>=5.8.0 in /usr/local/lib/python3.12/dist-packages (from distributed<2026.1.2,>=2026.1.1->rapids-dask-dependency==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (5.9.5)
Requirement already satisfied: sortedcontainers>=2.0.5 in /usr/local/lib/python3.12/dist-packages (from distributed<2026.1.2,>=2026.1.1->rapids-dask-dependency==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (2.4.0)
Requirement already satisfied: tblib!=3.2.0,!=3.2.1,>=1.6.0 in /usr/local/lib/python3.12/dist-packages (from distributed<2026.1.2,>=2026.1.1->rapids-dask-dependency==26.6.*,>=0.0.0a0->cugraph-cu12==26.06.*,>=0.0.0a0) (3.2.2)
Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.12/dist-packages (from Jinja2>=2.9->bokeh<=3.6.3,>=3.1->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.0.3)
Requirement already satisfied: anyio>=3.1.0 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (4.13.0)
Requirement already satisfied: argon2-cffi>=21.1 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (25.1.0)
Requirement already satisfied: jupyter-client>=7.4.4 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (7.4.9)
Requirement already satisfied: jupyter-core!=5.0.*,>=4.12 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (5.9.1)
Requirement already satisfied: jupyter-events>=0.9.0 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.12.1)
Requirement already satisfied: jupyter-server-terminals>=0.4.4 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.5.4)
Requirement already satisfied: nbconvert>=6.4.4 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (7.17.1)
Requirement already satisfied: nbformat>=5.3.0 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (5.10.4)
Requirement already satisfied: overrides>=5.0 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (7.7.0)
Requirement already satisfied: prometheus-client>=0.9 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.25.0)
Requirement already satisfied: pyzmq>=24 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (26.2.1)
Requirement already satisfied: send2trash>=1.8.2 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.1.0)
Requirement already satisfied: terminado>=0.8.3 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.18.1)
Requirement already satisfied: websocket-client>=1.7 in /usr/local/lib/python3.12/dist-packages (from jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.9.0)
Requirement already satisfied: mdurl~=0.1 in /usr/local/lib/python3.12/dist-packages (from markdown-it-py->panel>=1.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.1.2)
Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/dist-packages (from python-dateutil>=2.8.2->pandas<2.4.0,>=2.0->cudf-cu12==26.06.*,>=0.0.0a0) (1.17.0)
Requirement already satisfied: webencodings in /usr/local/lib/python3.12/dist-packages (from bleach->panel>=1.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.5.1)
Requirement already satisfied: uc-micro-py in /usr/local/lib/python3.12/dist-packages (from linkify-it-py->panel>=1.0->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.0.0)
Requirement already satisfied: argon2-cffi-bindings in /usr/local/lib/python3.12/dist-packages (from argon2-cffi>=21.1->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (25.1.0)
Requirement already satisfied: entrypoints in /usr/local/lib/python3.12/dist-packages (from jupyter-client>=7.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.4)
Requirement already satisfied: nest-asyncio>=1.5.4 in /usr/local/lib/python3.12/dist-packages (from jupyter-client>=7.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.6.0)
Requirement already satisfied: platformdirs>=2.5 in /usr/local/lib/python3.12/dist-packages (from jupyter-core!=5.0.*,>=4.12->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (4.9.6)
Requirement already satisfied: jsonschema>=4.18.0 in /usr/local/lib/python3.12/dist-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (4.26.0)
Requirement already satisfied: python-json-logger>=2.0.4 in /usr/local/lib/python3.12/dist-packages (from jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (4.1.0)
Requirement already satisfied: referencing in /usr/local/lib/python3.12/dist-packages (from jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.37.0)
Requirement already satisfied: rfc3339-validator in /usr/local/lib/python3.12/dist-packages (from jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.1.4)
Requirement already satisfied: rfc3986-validator>=0.1.1 in /usr/local/lib/python3.12/dist-packages (from jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.1.1)
Requirement already satisfied: beautifulsoup4 in /usr/local/lib/python3.12/dist-packages (from nbconvert>=6.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (4.13.5)
Requirement already satisfied: defusedxml in /usr/local/lib/python3.12/dist-packages (from nbconvert>=6.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.7.1)
Requirement already satisfied: jupyterlab-pygments in /usr/local/lib/python3.12/dist-packages (from nbconvert>=6.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.3.0)
Requirement already satisfied: mistune<4,>=2.0.3 in /usr/local/lib/python3.12/dist-packages (from nbconvert>=6.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.2.1)
Requirement already satisfied: nbclient>=0.5.0 in /usr/local/lib/python3.12/dist-packages (from nbconvert>=6.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.10.4)
Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.12/dist-packages (from nbconvert>=6.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.5.1)
Requirement already satisfied: fastjsonschema>=2.15 in /usr/local/lib/python3.12/dist-packages (from nbformat>=5.3.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.21.2)
Requirement already satisfied: ptyprocess in /usr/local/lib/python3.12/dist-packages (from terminado>=0.8.3->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.7.0)
Requirement already satisfied: tinycss2<1.5,>=1.1.0 in /usr/local/lib/python3.12/dist-packages (from bleach[css]!=5.0.0->nbconvert>=6.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.4.0)
Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /usr/local/lib/python3.12/dist-packages (from jsonschema>=4.18.0->jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2025.9.1)
Requirement already satisfied: rpds-py>=0.25.0 in /usr/local/lib/python3.12/dist-packages (from jsonschema>=4.18.0->jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (0.30.0)
Requirement already satisfied: fqdn in /usr/local/lib/python3.12/dist-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.5.1)
Requirement already satisfied: isoduration in /usr/local/lib/python3.12/dist-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (20.11.0)
Requirement already satisfied: jsonpointer>1.13 in /usr/local/lib/python3.12/dist-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.1.1)
Requirement already satisfied: rfc3987-syntax>=1.1.0 in /usr/local/lib/python3.12/dist-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.1.0)
Requirement already satisfied: uri-template in /usr/local/lib/python3.12/dist-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.3.0)
Requirement already satisfied: webcolors>=24.6.0 in /usr/local/lib/python3.12/dist-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (25.10.0)
Requirement already satisfied: cffi>=1.0.1 in /usr/local/lib/python3.12/dist-packages (from argon2-cffi-bindings->argon2-cffi>=21.1->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.0.0)
Requirement already satisfied: soupsieve>1.2 in /usr/local/lib/python3.12/dist-packages (from beautifulsoup4->nbconvert>=6.4.4->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (2.8.3)
Requirement already satisfied: pycparser in /usr/local/lib/python3.12/dist-packages (from cffi>=1.0.1->argon2-cffi-bindings->argon2-cffi>=21.1->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (3.0)
Requirement already satisfied: lark>=1.2.2 in /usr/local/lib/python3.12/dist-packages (from rfc3987-syntax>=1.1.0->jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.3.1)
Requirement already satisfied: arrow>=0.15.0 in /usr/local/lib/python3.12/dist-packages (from isoduration->jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.9.0->jupyter-server>=1.24.0->jupyter-server-proxy->cuxfilter-cu12==26.06.*,>=0.0.0a0) (1.4.0)
Downloading nvidia_libnvcomp_cu12-5.2.0.13-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (32.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 32.3/32.3 MB 59.7 MB/s eta 0:00:00
Downloading bokeh-3.6.3-py3-none-any.whl (6.9 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.9/6.9 MB 94.8 MB/s eta 0:00:00
Downloading datashader-0.19.1-py3-none-any.whl (10.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.7/10.7 MB 85.0 MB/s eta 0:00:00
Downloading holoviews-1.20.2-py3-none-any.whl (5.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.0/5.0 MB 89.4 MB/s eta 0:00:00
Downloading nvidia_nvimgcodec_cu12-0.8.0.22-py3-none-manylinux_2_28_x86_64.whl (34.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 34.3/34.3 MB 16.3 MB/s eta 0:00:00
Downloading nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl (39.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 39.7/39.7 MB 19.6 MB/s eta 0:00:00
Downloading panel-1.7.5-py3-none-any.whl (29.5 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 29.5/29.5 MB 72.4 MB/s eta 0:00:00
Downloading pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl (47.6 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 47.6/47.6 MB 17.5 MB/s eta 0:00:00
Downloading jupyter_server_proxy-4.5.0-py3-none-any.whl (45 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 45.1/45.1 kB 4.9 MB/s eta 0:00:00
Downloading simpervisor-1.0.0-py3-none-any.whl (8.3 kB)
Downloading pyct-0.6.0-py3-none-any.whl (16 kB)
Downloading nvidia_nvfatbin_cu12-12.9.82-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl (966 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 966.9/966.9 kB 58.9 MB/s eta 0:00:00
Installing collected packages: nvidia-libnvcomp-cu12, simpervisor, pyct, pyarrow, nvidia-nvjitlink-cu12, nvidia-nvimgcodec-cu12, nvidia-nvfatbin-cu12, librmm-cu12, libkvikio-cu12, libucxx-cu12, libcudf-cu12, rmm-cu12, cucim-cu12, bokeh, ucxx-cu12, rapids-dask-dependency, pylibcudf-cu12, panel, datashader, libraft-cu12, holoviews, distributed-ucxx-cu12, dask-cuda, pylibraft-cu12, libnvforest-cu12, libcuvs-cu12, cudf-cu12, raft-dask-cu12, nvforest-cu12, libcuml-cu12, libcugraph-cu12, dask-cudf-cu12, pylibcugraph-cu12, jupyter-server-proxy, cuml-cu12, nx-cugraph-cu12, cuxfilter-cu12, cugraph-cu12
  Attempting uninstall: nvidia-libnvcomp-cu12
    Found existing installation: nvidia-libnvcomp-cu12 5.1.0.21
    Uninstalling nvidia-libnvcomp-cu12-5.1.0.21:
      Successfully uninstalled nvidia-libnvcomp-cu12-5.1.0.21
  Attempting uninstall: pyarrow
    Found existing installation: pyarrow 18.1.0
    Uninstalling pyarrow-18.1.0:
      Successfully uninstalled pyarrow-18.1.0
  Attempting uninstall: nvidia-nvjitlink-cu12
    Found existing installation: nvidia-nvjitlink-cu12 12.8.93
    Uninstalling nvidia-nvjitlink-cu12-12.8.93:
      Successfully uninstalled nvidia-nvjitlink-cu12-12.8.93
  Attempting uninstall: nvidia-nvimgcodec-cu12
    Found existing installation: nvidia-nvimgcodec-cu12 0.7.0.11
    Uninstalling nvidia-nvimgcodec-cu12-0.7.0.11:
      Successfully uninstalled nvidia-nvimgcodec-cu12-0.7.0.11
  Attempting uninstall: librmm-cu12
    Found existing installation: librmm-cu12 26.2.0
    Uninstalling librmm-cu12-26.2.0:
      Successfully uninstalled librmm-cu12-26.2.0
  Attempting uninstall: libkvikio-cu12
    Found existing installation: libkvikio-cu12 26.2.0
    Uninstalling libkvikio-cu12-26.2.0:
      Successfully uninstalled libkvikio-cu12-26.2.0
  Attempting uninstall: libucxx-cu12
    Found existing installation: libucxx-cu12 0.48.0
    Uninstalling libucxx-cu12-0.48.0:
      Successfully uninstalled libucxx-cu12-0.48.0
  Attempting uninstall: libcudf-cu12
    Found existing installation: libcudf-cu12 26.2.1
    Uninstalling libcudf-cu12-26.2.1:
      Successfully uninstalled libcudf-cu12-26.2.1
  Attempting uninstall: rmm-cu12
    Found existing installation: rmm-cu12 26.2.0
    Uninstalling rmm-cu12-26.2.0:
      Successfully uninstalled rmm-cu12-26.2.0
  Attempting uninstall: cucim-cu12
    Found existing installation: cucim-cu12 26.2.0
    Uninstalling cucim-cu12-26.2.0:
      Successfully uninstalled cucim-cu12-26.2.0
  Attempting uninstall: bokeh
    Found existing installation: bokeh 3.8.2
    Uninstalling bokeh-3.8.2:
      Successfully uninstalled bokeh-3.8.2
  Attempting uninstall: ucxx-cu12
    Found existing installation: ucxx-cu12 0.48.0
    Uninstalling ucxx-cu12-0.48.0:
      Successfully uninstalled ucxx-cu12-0.48.0
  Attempting uninstall: rapids-dask-dependency
    Found existing installation: rapids-dask-dependency 26.2.0
    Uninstalling rapids-dask-dependency-26.2.0:
      Successfully uninstalled rapids-dask-dependency-26.2.0
  Attempting uninstall: pylibcudf-cu12
    Found existing installation: pylibcudf-cu12 26.2.1
    Uninstalling pylibcudf-cu12-26.2.1:
      Successfully uninstalled pylibcudf-cu12-26.2.1
  Attempting uninstall: panel
    Found existing installation: panel 1.9.0
    Uninstalling panel-1.9.0:
      Successfully uninstalled panel-1.9.0
  Attempting uninstall: libraft-cu12
    Found existing installation: libraft-cu12 26.2.0
    Uninstalling libraft-cu12-26.2.0:
      Successfully uninstalled libraft-cu12-26.2.0
  Attempting uninstall: holoviews
    Found existing installation: holoviews 1.22.1
    Uninstalling holoviews-1.22.1:
      Successfully uninstalled holoviews-1.22.1
  Attempting uninstall: distributed-ucxx-cu12
    Found existing installation: distributed-ucxx-cu12 0.48.0
    Uninstalling distributed-ucxx-cu12-0.48.0:
      Successfully uninstalled distributed-ucxx-cu12-0.48.0
  Attempting uninstall: dask-cuda
    Found existing installation: dask-cuda 26.2.0
    Uninstalling dask-cuda-26.2.0:
      Successfully uninstalled dask-cuda-26.2.0
  Attempting uninstall: pylibraft-cu12
    Found existing installation: pylibraft-cu12 26.2.0
    Uninstalling pylibraft-cu12-26.2.0:
      Successfully uninstalled pylibraft-cu12-26.2.0
  Attempting uninstall: libcuvs-cu12
    Found existing installation: libcuvs-cu12 26.2.0
    Uninstalling libcuvs-cu12-26.2.0:
      Successfully uninstalled libcuvs-cu12-26.2.0
  Attempting uninstall: cudf-cu12
    Found existing installation: cudf-cu12 26.2.1
    Uninstalling cudf-cu12-26.2.1:
      Successfully uninstalled cudf-cu12-26.2.1
  Attempting uninstall: raft-dask-cu12
    Found existing installation: raft-dask-cu12 26.2.0
    Uninstalling raft-dask-cu12-26.2.0:
      Successfully uninstalled raft-dask-cu12-26.2.0
  Attempting uninstall: libcuml-cu12
    Found existing installation: libcuml-cu12 26.2.0
    Uninstalling libcuml-cu12-26.2.0:
      Successfully uninstalled libcuml-cu12-26.2.0
  Attempting uninstall: libcugraph-cu12
    Found existing installation: libcugraph-cu12 26.2.0
    Uninstalling libcugraph-cu12-26.2.0:
      Successfully uninstalled libcugraph-cu12-26.2.0
  Attempting uninstall: dask-cudf-cu12
    Found existing installation: dask-cudf-cu12 26.2.1
    Uninstalling dask-cudf-cu12-26.2.1:
      Successfully uninstalled dask-cudf-cu12-26.2.1
  Attempting uninstall: pylibcugraph-cu12
    Found existing installation: pylibcugraph-cu12 26.2.0
    Uninstalling pylibcugraph-cu12-26.2.0:
      Successfully uninstalled pylibcugraph-cu12-26.2.0
  Attempting uninstall: cuml-cu12
    Found existing installation: cuml-cu12 26.2.0
    Uninstalling cuml-cu12-26.2.0:
      Successfully uninstalled cuml-cu12-26.2.0
  Attempting uninstall: nx-cugraph-cu12
    Found existing installation: nx-cugraph-cu12 26.2.0
    Uninstalling nx-cugraph-cu12-26.2.0:
      Successfully uninstalled nx-cugraph-cu12-26.2.0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
cudf-polars-cu12 26.2.1 requires pylibcudf-cu12==26.2.*, but you have pylibcudf-cu12 26.6.0a383 which is incompatible.
panel-material-ui 0.11.1 requires bokeh>=3.8.0, but you have bokeh 3.6.3 which is incompatible.
panel-material-ui 0.11.1 requires panel>=1.8.0, but you have panel 1.7.5 which is incompatible.
cuvs-cu12 26.2.0 requires libcuvs-cu12==26.2.*, but you have libcuvs-cu12 26.6.0a127 which is incompatible.
cuvs-cu12 26.2.0 requires pylibraft-cu12==26.2.*, but you have pylibraft-cu12 26.6.0a37 which is incompatible.
Successfully installed bokeh-3.6.3 cucim-cu12-26.6.0a38 cudf-cu12-26.6.0a383 cugraph-cu12-26.6.0a56 cuml-cu12-26.6.0a165 cuxfilter-cu12-26.6.0a11 dask-cuda-26.6.0a14 dask-cudf-cu12-26.6.0a383 datashader-0.19.1 distributed-ucxx-cu12-0.50.0a44 holoviews-1.20.2 jupyter-server-proxy-4.5.0 libcudf-cu12-26.6.0a383 libcugraph-cu12-26.6.0a56 libcuml-cu12-26.6.0a165 libcuvs-cu12-26.6.0a127 libkvikio-cu12-26.6.0a18 libnvforest-cu12-26.6.0a32 libraft-cu12-26.6.0a37 librmm-cu12-26.6.0a98 libucxx-cu12-0.50.0a44 nvforest-cu12-26.6.0a32 nvidia-libnvcomp-cu12-5.2.0.13 nvidia-nvfatbin-cu12-12.9.82 nvidia-nvimgcodec-cu12-0.8.0.22 nvidia-nvjitlink-cu12-12.9.86 nx-cugraph-cu12-26.6.0a11 panel-1.7.5 pyarrow-23.0.1 pyct-0.6.0 pylibcudf-cu12-26.6.0a383 pylibcugraph-cu12-26.6.0a56 pylibraft-cu12-26.6.0a37 raft-dask-cu12-26.6.0a37 rapids-dask-dependency-26.6.0a4 rmm-cu12-26.6.0a98 simpervisor-1.0.0 ucxx-cu12-0.50.0a44
```