### PR TITLE
Add SPDX headers and update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 
                                  Apache License
                            Version 2.0, January 2004

--- a/colab/env-check.py
+++ b/colab/env-check.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os, sys, io
 import subprocess
 from pathlib import Path

--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os, sys, io
 import subprocess
 from pathlib import Path

--- a/colab/pip-install.py
+++ b/colab/pip-install.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os, sys, io
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## Summary
- add Apache-2.0 SPDX headers to Python scripts
- update the root LICENSE file with the NVIDIA Apache 2.0 license text

## Notes
- SPDX headers are inserted after shebang and Python encoding declarations where present.