### PR TITLE
Add third-party license inventory

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,43 @@
+# Third-Party Licenses
+
+This file lists third-party libraries and imported modules identified in this repository, along with their license information and source references.
+
+Copyright cupy contributors - MIT
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to cupy.
+License Text(https://pypi.org/pypi/cupy/json)
+
+Copyright datetime contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to datetime.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright io contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to io.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright os contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to os.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright pandas contributors - BSD License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to pandas.
+License Text(https://pypi.org/pypi/pandas/json)
+
+Copyright pathlib contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to pathlib.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright pynvml contributors - BSD
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to pynvml.
+License Text(https://pypi.org/pypi/nvidia-ml-py/json)
+
+Copyright shutil contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to shutil.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright subprocess contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to subprocess.
+License Text(https://docs.python.org/3/license.html)
+
+Copyright sys contributors - Python Software Foundation License
+Attribution Statements: See the upstream license source for copyright and attribution notices applicable to sys.
+License Text(https://docs.python.org/3/license.html)


### PR DESCRIPTION
## Summary
- add THIRD_PARTY_LICENSES.md
- list imported libraries/modules, licenses, and source URLs from the provided inventory table

## Notes
- generated from the provided repo/top_level_import/license/source_url table