### PR TITLE
Add SPDX headers to shell and C++ files

### DIFF
--- a/colab/env-check.py
+++ b/colab/env-check.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os, sys, io

--- a/colab/install_rapids.py
+++ b/colab/install_rapids.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os, sys, io

--- a/colab/pip-install.py
+++ b/colab/pip-install.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os, sys, io

--- a/colab/rapids-colab.sh
+++ b/colab/rapids-colab.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 echo "PLEASE READ FOR 21.06"
 echo "********************************************************************************************************"

--- a/colab/update_gcc.sh
+++ b/colab/update_gcc.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 echo "Updating your Colab environment.  This will restart your kernel.  Don't Panic!"
 pip install -q condacolab
 pip uninstall -y cupy-cuda12x


### PR DESCRIPTION
## Summary
- add Apache-2.0 SPDX headers to shell scripts and C++ files
- preserve shell shebang placement where present
- replace `<year>` with `2026` in existing Python SPDX copyright headers

## Notes
- C++ files use block-comment SPDX headers.
- Shell scripts use `#` SPDX headers so scripts remain valid.